### PR TITLE
Bug fix: dropdown sometimes wouldn't close after the blur event

### DIFF
--- a/src/app/iq-select2/iq-select2.component.spec.ts
+++ b/src/app/iq-select2/iq-select2.component.spec.ts
@@ -71,12 +71,29 @@ describe('IqSelect2Component', () => {
         parent.detectChanges();
 
         hostComponent.childComponent.ngAfterViewInit();
+        hostComponent.childComponent.focusInput(null);
 
         hostComponent.childComponent.term.setValue('arg');
         tick(255);
         hostComponent.childComponent.term.setValue('');
         tick(255);
         expect(hostComponent.childComponent.resultsVisible).toBe(true);
+    })));
+
+    it('should not show results, when not focused',
+            inject([DataService], fakeAsync((service: DataService) => {
+        let parent = TestBed.createComponent(TestHostComponent);
+        let hostComponent: TestHostComponent = parent.componentInstance;
+        hostComponent.childComponent.dataSourceProvider = (term: string) => service.listData(term);
+        hostComponent.childComponent.iqSelect2ItemAdapter = adapter();
+        parent.detectChanges();
+
+        hostComponent.childComponent.ngAfterViewInit();
+
+        hostComponent.childComponent.term.setValue('');
+        tick(255);
+
+        expect(hostComponent.childComponent.resultsVisible).toBe(false);
     })));
 
     it('should hide results after deleting text, when term.length < minimumInputLength', fakeAsync((service: DataService) => {

--- a/src/app/iq-select2/iq-select2.component.ts
+++ b/src/app/iq-select2/iq-select2.component.ts
@@ -102,7 +102,8 @@ export class IqSelect2Component<T> implements AfterViewInit, ControlValueAccesso
             .debounceTime(this.searchDelay)
             .distinctUntilChanged()
             .subscribe(term => {
-                this.resultsVisible = term.length >= this.minimumInputLength;
+                this.resultsVisible = term.length > 0 ||
+                    (this.searchFocused && this.forceVisibility && term.length >= this.minimumInputLength);
                 this.filterData(this.term.value);
             });
     }


### PR DESCRIPTION
On blur the term is set to an empty string, which triggers the subscribe function if the term wasn't empty before. Before my change resultsVisible would then result in true, even if the select isn't focused anymore.