### PR TITLE
fixed selectedItems not being updated correctly when calling patchValue (multiple, entity reference)

### DIFF
--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.spec.ts
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.spec.ts
@@ -825,6 +825,34 @@ describe('IqSelect2Component', () => {
 
         expect(component.fullDataList.map(item => item.id).indexOf('16')).toBeGreaterThanOrEqual(0);
     });
+
+    it('multiple mode with entity reference should only set the given values as selected, when writeValue ist called', () => {
+        const itemToBeRemoved = {
+            id: '1',
+            name: 'item 1',
+        };
+        const itemToStay = {
+            id: '2',
+            name: 'item 2',
+        };
+        const itemToBeAdded = {
+            id: '3',
+            name: 'item 3',
+        };
+
+        const iqSelect2ItemAdapter = adapter();
+        component.multiple = true;
+        component.referenceMode = 'entity';
+        component.iqSelect2ItemAdapter = iqSelect2ItemAdapter;
+        component.selectedItems = [itemToBeRemoved, itemToStay].map(iqSelect2ItemAdapter);
+
+        component.writeValue([itemToStay, itemToBeAdded]);
+
+        expect(component.selectedItems.length).toBe(2);
+        const selectedEntities = component.selectedItems.map(x => x.entity);
+        expect(selectedEntities).toContain(itemToStay);
+        expect(selectedEntities).toContain(itemToBeAdded);
+    });
 });
 
 @Component({

--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
@@ -145,12 +145,13 @@ export class IqSelect2Component<T> implements AfterViewInit, ControlValueAccesso
     }
 
     private handleMultipleWithEntities(selectedValues: any) {
+        this.selectedItems = [];
         selectedValues.forEach((entity) => {
             let item = this.iqSelect2ItemAdapter(entity);
             let ids = this.getSelectedIds();
 
             if (ids.indexOf(item.id) === -1) {
-                this.selectedItems.push(item)
+                this.selectedItems.push(item);
             }
         });
     }


### PR DESCRIPTION
In the current release, when using multiple mode with entity reference, there is the following bug: When calling set/patchValue then new items are added to the selection, but old items aren't removed. 
This PR fixes that.