### PR TITLE
Add directive to handle custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ import { IqSelect2Module } from 'ng2-iq-select2';
 </form>
 ```
 
+*html file (custom template)*
+```html
+<form [formGroup]="form">
+  <iq-select2 css="form-control input-sm" 
+                formControlName="country" 
+                [dataSourceProvider]="listCountries"
+                [selectedProvider]="loadFromIds"
+                [iqSelect2ItemAdapter]="adapter">
+    <div *iq-select2-template="let item = $entity; let i = $index">
+      <span [style.color]="item.color">[{{item.code}}]</span> {{item.name}}
+    </div>
+  </iq-select2>
+</form>
+```
+> Exposed internal variable to bind `$item`, `$entity`, `$id`, `$index`
+
 *example typescript file*
 ```javascript
 export class Example {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -81,7 +81,7 @@
                     [iqSelect2ItemAdapter]="entityToIqSelect2Item"
                     [minimumInputLength]='0' referenceMode='entity' (onSelect)="onSelect($event)"
                     (onRemove)="onRemove($event)" [selectedProvider]="getItems" [clientMode]="true">
-          <div *iq-select2-template="let item = $item; let i = $index">
+          <div *iq-select2-template="let item = $entity; let i = $index">
             <span [style.color]="item.color">[{{item.code}}]</span> {{item.name}}
           </div>
         </iq-select2>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -74,6 +74,19 @@
                         (onRemove)="onRemove($event)" [selectedProvider]="getItems"></iq-select2>
         </div>
 
+      <div class="form-group">
+        <label>Country Custom Template</label>
+        <iq-select2 css="form-control input-sm" placeholder="Start writing..." formControlName="countrySingleMin0"
+                    [dataSourceProvider]="listItems"
+                    [iqSelect2ItemAdapter]="entityToIqSelect2Item"
+                    [minimumInputLength]='0' referenceMode='entity' (onSelect)="onSelect($event)"
+                    (onRemove)="onRemove($event)" [selectedProvider]="getItems" [clientMode]="true">
+          <div *iq-select2-template="let item = $item; let i = $index">
+            <span [style.color]="item.color">[{{item.code}}]</span> {{item.name}}
+          </div>
+        </iq-select2>
+      </div>
+
         <button class="btn btn-primary" type="submit" (click)="send(form.value)">Send</button>
         <button type="button" (click)="reset()">Reset</button>
     </form>

--- a/src/app/component-wrapper/README.md
+++ b/src/app/component-wrapper/README.md
@@ -21,7 +21,7 @@ Angular 2 native select 2 implementation based on bootstrap 3
 Usage example:
 
 *app.module.ts*
-```javascript
+```typescript
 
 import { IqSelect2Module } from 'ng2-iq-select2';
 
@@ -42,8 +42,24 @@ import { IqSelect2Module } from 'ng2-iq-select2';
 </form>
 ```
 
+*html file (custom template)*
+```html
+<form [formGroup]="form">
+  <iq-select2 css="form-control input-sm" 
+                formControlName="country" 
+                [dataSourceProvider]="listCountries"
+                [selectedProvider]="loadFromIds"
+                [iqSelect2ItemAdapter]="adapter">
+    <div *iq-select2-template="let item = $entity; let i = $index">
+      <span [style.color]="item.color">[{{item.code}}]</span> {{item.name}}
+    </div>
+  </iq-select2>
+</form>
+```
+> Exposed internal variable to bind `$item`, `$entity`, `$id`, `$index`
+
 *example typescript file*
-```javascript
+```typescript
 export class Example {
     form: FormGroup;
     listCountries: (term: string) => Observable<Country[]>;

--- a/src/app/component-wrapper/component.ts
+++ b/src/app/component-wrapper/component.ts
@@ -3,3 +3,4 @@ export {IqSelect2Component} from './src/app/iq-select2/iq-select2.component';
 export {IqSelect2Item} from './src/app/iq-select2/iq-select2-item';
 export {IqSelect2ResultsComponent} from './src/app/iq-select2-results/iq-select2-results.component';
 export {Messages} from './src/app/iq-select2/messages';
+

--- a/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.html
+++ b/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.html
@@ -4,7 +4,9 @@
              (mousedown)="onItemSelected(item)" [class.selected]="isSelected(item)"
              [class.active]="i === activeIndex"
              (mouseover)="onMouseOver(i)"
-             (mouseenter)="onHovering($event)">{{item.text}}
+             (mouseenter)="onHovering($event)">
+            <ng-container [ngTemplateOutlet]="templateRef" [ngOutletContext]="{$item:item.entity, $id:item.id, $index:i}"></ng-container>
+            <ng-container *ngIf="!templateRef">{{item.text}}</ng-container>
         </div>
     </div>
 </div>

--- a/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.html
+++ b/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.html
@@ -5,7 +5,7 @@
              [class.active]="i === activeIndex"
              (mouseover)="onMouseOver(i)"
              (mouseenter)="onHovering($event)">
-            <ng-container [ngTemplateOutlet]="templateRef" [ngOutletContext]="{$item:item.entity, $id:item.id, $index:i}"></ng-container>
+            <ng-container [ngTemplateOutlet]="templateRef" [ngOutletContext]="{$item:item, $entity: item.entity, $id:item.id, $index:i}"></ng-container>
             <ng-container *ngIf="!templateRef">{{item.text}}</ng-container>
         </div>
     </div>

--- a/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, TemplateRef } from '@angular/core';
 import {IqSelect2Item} from '../iq-select2/iq-select2-item';
 
 @Component({
@@ -11,6 +11,7 @@ export class IqSelect2ResultsComponent implements OnInit {
     @Input() items: IqSelect2Item[];
     @Input() searchFocused: boolean;
     @Input() selectedItems: IqSelect2Item[];
+    @Input() templateRef: TemplateRef<any>;
     @Output() itemSelectedEvent: EventEmitter<any> = new EventEmitter();
     activeIndex: number = 0;
     private ussingKeys = false;

--- a/src/app/component-wrapper/src/app/iq-select2-template/iq-select2-template.directive.spec.ts
+++ b/src/app/component-wrapper/src/app/iq-select2-template/iq-select2-template.directive.spec.ts
@@ -1,0 +1,94 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { IqSelect2ResultsComponent } from '../iq-select2-results/iq-select2-results.component';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Country, DataService } from '../../../../data.service';
+import { BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { IqSelect2Component } from '../iq-select2/iq-select2.component';
+import { IqSelect2TemplateDirective } from './iq-select2-template.directive';
+
+describe('IqSelect2TemplateDirective', () => {
+  let component: IqSelect2Component<Country>;
+  let parentFixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [IqSelect2Component, IqSelect2TemplateDirective, IqSelect2ResultsComponent, TestHostComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        DataService,
+        MockBackend,
+        BaseRequestOptions, {
+          provide: Http,
+          useFactory: (mockBackend, options) => {
+            return new Http(mockBackend, options);
+          },
+          deps: [MockBackend, BaseRequestOptions]
+        }]
+    })
+      .compileComponents();
+  }));
+
+  const adapter = function () {
+    return (entity: any) => {
+      return {
+        id: entity.id,
+        text: entity.name,
+        entity: entity
+      };
+    };
+  };
+
+  beforeEach(inject([DataService], (service: DataService) => {
+    parentFixture = TestBed.createComponent(TestHostComponent);
+    const parentComponent = parentFixture.componentInstance;
+    component = parentComponent.childComponent;
+    component.dataSourceProvider = (term: string) => service.listData(term);
+    component.iqSelect2ItemAdapter = adapter();
+    parentFixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display custom result template', inject([DataService], fakeAsync(() => {
+    component.searchFocused = true;
+    component.term.setValue('tunisia');
+    tick(250);
+    parentFixture.detectChanges();
+    const container: NodeSelector = parentFixture.nativeElement.querySelector('.select2-result.active');
+    // query dom based on class from custom template
+    expect(container.querySelector('.color').innerHTML).toBe('#fcd217');
+    expect(container.querySelector('.code').innerHTML).toBe('TN');
+  })));
+});
+
+@Component({
+  template: `
+    <form [formGroup]="fg">
+      <iq-select2 [minimumInputLength]="0">
+        <div *iq-select2-template="let item = $entity; let i = $index">
+          ({{i}}) <span class="code">{{item.code}}</span> - <span class="color">{{item.color}}</span>
+        </div>
+      </iq-select2>
+    </form>
+  `
+})
+class TestHostComponent implements OnInit {
+
+  @ViewChild(IqSelect2Component)
+  childComponent: IqSelect2Component<Country>;
+  fg: FormGroup;
+
+  constructor(private formBuilder: FormBuilder) {
+  }
+
+  ngOnInit(): void {
+    this.fg = this.formBuilder.group({
+      country: null
+    });
+  }
+}

--- a/src/app/component-wrapper/src/app/iq-select2-template/iq-select2-template.directive.ts
+++ b/src/app/component-wrapper/src/app/iq-select2-template/iq-select2-template.directive.ts
@@ -1,0 +1,14 @@
+/**
+ * @author:msms
+ * 11-Jun-17
+ */
+import { Directive, Host, TemplateRef } from '@angular/core';
+import { IqSelect2Component } from '../iq-select2/iq-select2.component';
+@Directive({selector: '[iq-select2-template]'})
+export class IqSelect2TemplateDirective<T> {
+  constructor(private templateRef: TemplateRef<T>, @Host() host: IqSelect2Component<T>) {
+    if (host instanceof IqSelect2Component) {
+      host.templateRef = templateRef;
+    }
+  }
+}

--- a/src/app/component-wrapper/src/app/iq-select2.module.ts
+++ b/src/app/component-wrapper/src/app/iq-select2.module.ts
@@ -1,27 +1,30 @@
-import {NgModule} from '@angular/core';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {HttpModule} from '@angular/http';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
-import {IqSelect2Component} from './iq-select2/iq-select2.component';
-import {IqSelect2ResultsComponent} from './iq-select2-results/iq-select2-results.component';
-import {CommonModule} from '@angular/common';
+import { IqSelect2Component } from './iq-select2/iq-select2.component';
+import { IqSelect2ResultsComponent } from './iq-select2-results/iq-select2-results.component';
+import { CommonModule } from '@angular/common';
+import { IqSelect2TemplateDirective } from './iq-select2-template/iq-select2-template.directive';
 
 @NgModule({
-    declarations: [
-        IqSelect2Component,
-        IqSelect2ResultsComponent
-    ],
-    imports: [
-        CommonModule,
-        FormsModule,
-        HttpModule,
-        ReactiveFormsModule
-    ],
-    exports: [
-        IqSelect2Component,
-        IqSelect2ResultsComponent
-    ]
+  declarations: [
+    IqSelect2Component,
+    IqSelect2ResultsComponent,
+    IqSelect2TemplateDirective
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    HttpModule,
+    ReactiveFormsModule
+  ],
+  exports: [
+    IqSelect2Component,
+    IqSelect2ResultsComponent,
+    IqSelect2TemplateDirective
+  ]
 })
 export class IqSelect2Module {
 }

--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.html
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.html
@@ -36,6 +36,7 @@
         </span>
         <iq-select2-results #results [selectedItems]="selectedItems" [items]="listData"
                             (itemSelectedEvent)="onItemSelected($event);"
+                            [templateRef]="templateRef"
                             [searchFocused]="searchFocused"></iq-select2-results>
     </div>
 </div>

--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, EventEmitter, forwardRef, Input, Output, ViewChild} from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, forwardRef, Input, Output, TemplateRef, ViewChild } from '@angular/core';
 import {IqSelect2Item} from './iq-select2-item';
 import {IqSelect2ResultsComponent} from '../iq-select2-results/iq-select2-results.component';
 import {ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR} from '@angular/forms';
@@ -51,6 +51,7 @@ export class IqSelect2Component<T> implements AfterViewInit, ControlValueAccesso
     @Output() onRemove: EventEmitter<IqSelect2Item> = new EventEmitter<IqSelect2Item>();
     @ViewChild('termInput') private termInput;
     @ViewChild('results') results: IqSelect2ResultsComponent;
+    templateRef: TemplateRef<T>;
     term = new FormControl();
     resultsVisible = false;
     listData: IqSelect2Item[];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/598188/27011944-6065e596-4ef9-11e7-9322-3091cdebd315.png)

* Apply by put `*iq-select2-template` structural directive inside `<iq-select2>` tag.
* 3 property is assigned to _TemplateRef_ context:
  - `$item` - Entity object
  - `$id` - Object Id
  - `$index` - Current Index

![image](https://user-images.githubusercontent.com/598188/27011892-b0fa191a-4ef8-11e7-9c53-e55340448f56.png)
* Request PR in case useful for others. Not sure is it a correct way to do it. Please advise
* At least could give some idea to enhance this component