### PR TITLE
fixes #39: remove source files from npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # compiled output
 /dist
+/publish
 /tmp
 /lib
 /aot

--- a/build-lib.js
+++ b/build-lib.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const os = require("os");
+const glob = require("glob");
+const child_process = require('child_process');
+const rimraf = require('rimraf');
+const ncp = require('ncp');
+
+console.log('clean publish directory');
+if(fs.existsSync('publish')){
+  rimraf.sync('publish');
+}
+
+console.log('copy files to publish directory');
+const copyOptions = {
+  filter: filename => !filename.endsWith('.spec.ts')
+};
+ncp('src/app/component-wrapper/','publish/', copyOptions, error => {
+  console.log('inline templates and styles');
+  const ngInlineCmd = os.platform() === 'win32' ? 'node_modules\\.bin\\ng2-inline' : './node_modules/.bin/ng2-inline';
+  child_process.execSync(ngInlineCmd + ' --flatten --relative publish/**/*.component.ts', {stdio:[0,1,2]});
+
+  console.log('compile typescript');
+  const ngcCmd = os.platform() === 'win32' ? 'node_modules\\.bin\\ngc' : './node_modules/.bin/ngc';
+  child_process.execSync(ngcCmd + ' -p publish/tsconfig.json', {stdio:[0,1,2]});
+});

--- a/build-lib.js
+++ b/build-lib.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const os = require("os");
-const glob = require("glob");
 const child_process = require('child_process');
 const rimraf = require('rimraf');
 const ncp = require('ncp');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "ng test -w false --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "mypublish": "node build-lib.js && cd publish && npm publish"
+    "mypublish": "node build-lib.js && cd publish && npm publish",
+    "mypublish:test": "node build-lib.js && cd publish && npm pack"
   },
   "dependencies": {
     "@angular/common": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "ng test -w false --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "mypublish": "node build-lib.js && cd publish && npm pack"
+    "mypublish": "node build-lib.js && cd publish && npm publish"
   },
   "dependencies": {
     "@angular/common": "^2.4.0",
@@ -27,7 +27,7 @@
     "zone.js": "^0.7.6"
   },
   "devDependencies": {
-    "@angular/cli": "^1.0.0-rc.1",
+    "@angular/cli": "^1.1.3",
     "@angular/compiler-cli": "^2.4.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "ng test -w false --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "clean": "cd ./src/app/component-wrapper && npm run clean"
+    "mypublish": "node build-lib.js && cd publish && npm pack"
   },
   "dependencies": {
     "@angular/common": "^2.4.0",
@@ -31,6 +31,7 @@
     "@angular/compiler-cli": "^2.4.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",
+    "angular2-inline-template-style": "^1.1.0",
     "codelyzer": "~2.0.0",
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
@@ -40,7 +41,9 @@
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "ncp": "^2.0.0",
     "protractor": "~5.1.0",
+    "rimraf": "^2.6.1",
     "ts-node": "~2.0.0",
     "tslint": "~4.4.2",
     "typescript": "~2.0.0"

--- a/src/app/component-wrapper/.npmignore
+++ b/src/app/component-wrapper/.npmignore
@@ -1,0 +1,7 @@
+# Ignore Typescript source files
+*.ts
+!*.d.ts
+!*.ngfactory.ts
+
+# Ignore AOT generated files
+*.ngsummary.json

--- a/src/app/component-wrapper/.npmignore
+++ b/src/app/component-wrapper/.npmignore
@@ -1,7 +1,15 @@
 # Ignore Typescript source files
 *.ts
 !*.d.ts
-!*.ngfactory.ts
 
 # Ignore AOT generated files
 *.ngsummary.json
+*.ngfactory.ts
+
+# Ignore inlined files
+*.css
+*.html
+
+# Other
+tsconfig.json
+.npmignore

--- a/src/app/component-wrapper/package.json
+++ b/src/app/component-wrapper/package.json
@@ -6,16 +6,6 @@
   "repository": {
     "url": "https://github.com/Innqube/ng2-iq-select2"
   },
-  "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e",
-    "clean": "find . ( -name '*.js.map' -o -name '*.js' -o -name '*.d.ts' -o -name '*.ngfactory.ts' -o -name '*.ngsummary.json' -o -name '*.metadata.json' -o -name '*.ngstyle.ts' ) -type f -delete",
-    "prepublish": "node ./../../../node_modules/@angular/compiler-cli/src/main.js"
-  },
   "keywords": [
     "ng",
     "ng2",

--- a/src/app/component-wrapper/package.json
+++ b/src/app/component-wrapper/package.json
@@ -13,8 +13,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "clean": "find . -name '*.js.map' -type f -delete && find . -name '*.js' -type f -delete && find . -name '*.d.ts' -type f -delete",
-    "prepublish": "tsc"
+    "clean": "find . ( -name '*.js.map' -o -name '*.js' -o -name '*.d.ts' -o -name '*.ngfactory.ts' -o -name '*.ngsummary.json' -o -name '*.metadata.json' -o -name '*.ngstyle.ts' ) -type f -delete",
+    "prepublish": "node ./../../../node_modules/@angular/compiler-cli/src/main.js"
   },
   "keywords": [
     "ng",

--- a/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2-results/iq-select2-results.component.ts
@@ -3,8 +3,8 @@ import {IqSelect2Item} from '../iq-select2/iq-select2-item';
 
 @Component({
     selector: 'iq-select2-results',
-    templateUrl: 'iq-select2-results.component.html',
-    styleUrls: ['iq-select2-results.component.css']
+    templateUrl: './iq-select2-results.component.html',
+    styleUrls: ['./iq-select2-results.component.css']
 })
 export class IqSelect2ResultsComponent implements OnInit {
 

--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
@@ -20,8 +20,8 @@ const noop = () => {
 
 @Component({
     selector: 'iq-select2',
-    templateUrl: 'iq-select2.component.html',
-    styleUrls: ['iq-select2.component.css'],
+    templateUrl: './iq-select2.component.html',
+    styleUrls: ['./iq-select2.component.css'],
     providers: [VALUE_ACCESSOR]
 })
 export class IqSelect2Component<T> implements AfterViewInit, ControlValueAccessor {

--- a/src/app/component-wrapper/tsconfig.json
+++ b/src/app/component-wrapper/tsconfig.json
@@ -17,6 +17,10 @@
       "node"
     ]
   },
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "genDir": "."
+  },
   "exclude": [
     "test.ts",
     "**/*.spec.ts",


### PR DESCRIPTION
This PR fixes #39 by adding a npm run mypublish command, which copies the component-wrapper folder, inlines the templates/styles and the builds it. This doesn't use the Angular Package Format, but everyone which could use the library until now, should be able to still use it with this PR. 

I tested it with my own app, which uses angular-cli and I had no problems with ng serve and building it with AOT enabled. 