### PR TITLE
Allows for the selectbox to display selected values with index '0'

### DIFF
--- a/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
+++ b/src/app/component-wrapper/src/app/iq-select2/iq-select2.component.ts
@@ -73,7 +73,7 @@ export class IqSelect2Component implements AfterViewInit, ControlValueAccessor {
     }
 
     writeValue(selectedValues: any): void {
-        if (selectedValues) {
+        if (selectedValues || selectedValues === 0) {
             if (this.referenceMode === 'id') {
                 this.populateItemsFromIds(selectedValues);
             } else {


### PR DESCRIPTION
Prior to this change the selectbox wasn't able to display selected values (reference-mode:id) with index '0' (as number, not string). An example would be enum properties which are bound to the selectbox by id. Although it's possible to select an enum value with id '0' and save it (assuming we can save the selected value to a database), reloading it from aforementioned database prevents it from beeing displayed in the selectbox, 'undefined' (or nothing) is displayed instead. This change allows for the selectbox to display enum values with index '0' (or values with index '0' in general).